### PR TITLE
Add checkpoint after DGW

### DIFF
--- a/src/checkpoints.cpp
+++ b/src/checkpoints.cpp
@@ -36,14 +36,15 @@ namespace Checkpoints
     static MapCheckpoints mapCheckpoints =
         boost::assign::map_list_of
                ( 0, uint256("0x721abe3814e15f1ab50514c8b7fffa7578c1f35aa915275ee91f4cb8d02be5c4"))
-			   ( 10020, uint256("0x57d946045198f3493a18fdc5a6fdc67aa30c9055429d446718d61e6547355147"))
+	       ( 10020, uint256("0x57d946045198f3493a18fdc5a6fdc67aa30c9055429d446718d61e6547355147"))
+	       ( 152005, uint256("0x1e6ecdd1f4ffded504d0664638de90441c9f27653a29ea45b1656624115bd85a"))
 	;
     static const CCheckpointData data = {
         &mapCheckpoints,
         1388880557, // * UNIX timestamp of last checkpoint block
         0,    // * total number of transactions between genesis and last checkpoint
                     //   (the tx=... number in the SetBestChain debug.log lines)
-        8000.0     // * estimated number of transactions per day after checkpoint
+        75.0     // * estimated number of transactions per day after checkpoint
     };
 
     static MapCheckpoints mapCheckpointsTestnet = 


### PR DESCRIPTION
I think this makes for a good checkpoint, in part because it's after the double spend attack and DGW switch, and in part because it has 1½+ minutes on either side so most likely no conflicting timestamps. Would someone mind filling out the unix timestamp and transaction count that'd be nice (Haven't bothered fixing Rackle yet, so can't check myself).